### PR TITLE
[WIP] Support for F#

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [1.2.0] - 2019-12-24
+
+### Added
+- Added support for F# projects.
+
+
 ## [1.1.0] - 2019-02-23
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-dotnet-auto-attach",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-dotnet-auto-attach",
 	"displayName": ".NET Auto Attach",
 	"description": "Automatically attach the debugger to a dotnet process started with dotnet-watch.",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"publisher": "DennisMaxJung",
 	"engines": {
 		"vscode": "^1.31.1"
@@ -16,6 +16,7 @@
 	],
 	"keywords": [
 		"C#",
+		"F#",
 		"multi-root ready",
 		"dotnet watch"
 	],
@@ -40,6 +41,7 @@
 	"activationEvents": [
 		"onDebug",
 		"onLanguage:csharp",
+		"onLanguage:fsharp",
 		"*"
 	],
 	"main": "./out/extension",

--- a/src/dotNetAutoAttachDebugConfigurationProvider.ts
+++ b/src/dotNetAutoAttachDebugConfigurationProvider.ts
@@ -3,8 +3,8 @@
  * @Author: Dennis Jung
  * @Author: Konrad Müller
  * @Date: 2019-02-16 22:01:33
- * @Last Modified by: Dennis Jung
- * @Last Modified time: 2019-02-19 13:51:15
+ * @Last Modified by: Luiz Stangarlin
+ * @Last Modified time: 2019-12-24 12:41:07
  */
 
 import {
@@ -17,6 +17,7 @@ import {
 } from "vscode";
 import DotNetAutoAttach from "./dotNetAutoAttach";
 import IDotNetAutoAttachDebugConfiguration from "./interfaces/IDotNetAutoAttachDebugConfiguration";
+import DotNetAutoAttachProject from "./models/dotNetAutoAttachProject";
 
 /**
  * The DotNetAutoAttachDebugConfigurationProvider.
@@ -93,9 +94,10 @@ export default class DotNetAutoAttachDebugConfigurationProvider
 	 */
 	public provideDebugConfigurations(folder: WorkspaceFolder | undefined, token?: CancellationToken): ProviderResult<Array<IDotNetAutoAttachDebugConfiguration>> {
 		if (folder) {
+			const glob = DotNetAutoAttachProject.FilesGlob;
 			return Promise.resolve(
-				workspace.findFiles("**/*.csproj").then(k => {
-					var tmp = k.filter(m =>
+				workspace.findFiles(glob).then(k => {
+					const tmp = k.filter(m =>
 						m.toString().startsWith(folder.uri.toString())
 					);
 					if (tmp.length > 1) {

--- a/src/models/DotNetAutoAttachProject.ts
+++ b/src/models/DotNetAutoAttachProject.ts
@@ -3,7 +3,7 @@
  * @Author: Luiz Stangarlin
  * @Date: 2019-12-24 12:40:26
  * @Last Modified by: Luiz Stangarlin
- * @Last Modified time: 2019-12-24 12:40:26
+ * @Last Modified time: 2019-12-24 15:14:39
  */
 
 /**
@@ -18,7 +18,7 @@ export default class DotNetAutoAttachProject {
 	/**
 	 * The supported kinds of projects.
 	 *
-	 * @public
+	 * @private
 	 * @static
 	 * @returns {Array<string>}
 	 * @memberof DotNetAutoAttachProject
@@ -57,7 +57,7 @@ export default class DotNetAutoAttachProject {
 	/**
 	 * Regex for finding the project name.
 	 *
-	 * @public
+	 * @private
 	 * @static
 	 * @returns {string}
 	 * @memberof DotNetAutoAttachProject
@@ -65,8 +65,18 @@ export default class DotNetAutoAttachProject {
 	private static nameRegex: RegExp = (() => {
 		const capture =
 			DotNetAutoAttachProject.supportedProjectKinds.join("|");
-		return RegExp(`/^.+(?:\/|\\).+[.](${capture})/`);
+		return RegExp(`^.*[\\/\\\\](.+[.](${capture}))$`);
 	})();
+
+	/**
+	 * Regex for finding the project path without root.
+	 *
+	 * @private
+	 * @static
+	 * @returns {string}
+	 * @memberof DotNetAutoAttachProject
+	 */
+	private static rootRegex: RegExp = /^[\\/\\\\](.+)$/;
 
 	/**
 	 * Extract the project name from the project path.
@@ -78,9 +88,26 @@ export default class DotNetAutoAttachProject {
 	 */
 	public static extractProjectName(fsPath: string): string | undefined {
 		const name_regex = DotNetAutoAttachProject.nameRegex;
-		let matches = name_regex.exec(fsPath);
-		if (matches && matches.length === 1) {
-			return matches[0];
+		const matches = name_regex.exec(fsPath);
+		if (matches && matches.length === 3) {
+			return matches[1];
+		}
+		return undefined;
+	}
+
+	/**
+	 * Extract the project name from the project path.
+	 *
+	 * @public
+	 * @static
+	 * @returns {string | undefined}
+	 * @memberof DotNetAutoAttachProject
+	 */
+	public static extractProjectPath(fsPath: string): string | undefined {
+		const root_regex = DotNetAutoAttachProject.rootRegex;
+		const matches = root_regex.exec(fsPath);
+		if (matches && matches.length === 2) {
+			return matches[1];
 		}
 		return undefined;
 	}

--- a/src/models/DotNetAutoAttachProject.ts
+++ b/src/models/DotNetAutoAttachProject.ts
@@ -1,0 +1,88 @@
+/*
+ * @file Contains the DotNetAutoAttachProject.
+ * @Author: Luiz Stangarlin
+ * @Date: 2019-12-24 12:40:26
+ * @Last Modified by: Luiz Stangarlin
+ * @Last Modified time: 2019-12-24 12:40:26
+ */
+
+/**
+ * The DotNetAutoAttachProject.
+ *
+ * @export
+ * @class DotNetAutoAttachProject
+ * @implements {DebugConfigurationProvider}
+ */
+export default class DotNetAutoAttachProject {
+
+	/**
+	 * The supported kinds of projects.
+	 *
+	 * @public
+	 * @static
+	 * @returns {Array<string>}
+	 * @memberof DotNetAutoAttachProject
+	 */
+	private static supportedProjectKinds = [
+		"csproj",
+		"fsproj",
+	];
+
+	/**
+	 * Get the list of support project file extensions.
+	 *
+	 * @public
+	 * @static
+	 * @returns {string}
+	 * @memberof DotNetAutoAttachProject
+	 */
+	public static get SupportedFileExtensions(): Array<string> {
+		return DotNetAutoAttachProject.supportedProjectKinds;
+	}
+
+	/**
+	 * Get the glob for finding project files.
+	 *
+	 * @public
+	 * @static
+	 * @returns {string}
+	 * @memberof DotNetAutoAttachProject
+	 */
+	public static get FilesGlob(): string {
+		const glob =
+			DotNetAutoAttachProject.supportedProjectKinds.join(",");
+		return `**/*.{${glob}}`;
+	}
+
+	/**
+	 * Regex for finding the project name.
+	 *
+	 * @public
+	 * @static
+	 * @returns {string}
+	 * @memberof DotNetAutoAttachProject
+	 */
+	private static nameRegex: RegExp = (() => {
+		const capture =
+			DotNetAutoAttachProject.supportedProjectKinds.join("|");
+		return RegExp(`/^.+(?:\/|\\).+[.](${capture})/`);
+	})();
+
+	/**
+	 * Extract the project name from the project path.
+	 *
+	 * @public
+	 * @static
+	 * @returns {string | undefined}
+	 * @memberof DotNetAutoAttachProject
+	 */
+	public static extractProjectName(fsPath: string): string | undefined {
+		const name_regex = DotNetAutoAttachProject.nameRegex;
+		let matches = name_regex.exec(fsPath);
+		if (matches && matches.length === 1) {
+			return matches[0];
+		}
+		return undefined;
+	}
+
+}

--- a/src/models/DotNetAutoAttachProject.ts
+++ b/src/models/DotNetAutoAttachProject.ts
@@ -3,7 +3,7 @@
  * @Author: Luiz Stangarlin
  * @Date: 2019-12-24 12:40:26
  * @Last Modified by: Luiz Stangarlin
- * @Last Modified time: 2019-12-24 15:14:39
+ * @Last Modified time: 2019-12-25 02:28:02
  */
 
 /**
@@ -79,7 +79,7 @@ export default class DotNetAutoAttachProject {
 	private static rootRegex: RegExp = /^[\\/\\\\](.+)$/;
 
 	/**
-	 * Extract the project name from the project path.
+	 * Extract the project name from the project file path.
 	 *
 	 * @public
 	 * @static
@@ -96,7 +96,7 @@ export default class DotNetAutoAttachProject {
 	}
 
 	/**
-	 * Extract the project name from the project path.
+	 * Extract the project path from the project file path.
 	 *
 	 * @public
 	 * @static

--- a/src/models/DotNetAutoAttachTask.ts
+++ b/src/models/DotNetAutoAttachTask.ts
@@ -4,7 +4,7 @@
  * @Author: Konrad Müller
  * @Date: 2018-06-15 14:34:31
  * @Last Modified by: Luiz Stangarlin
- * @Last Modified time: 2019-12-24 14:48:51
+ * @Last Modified time: 2019-12-25 02:41:25
  */
 
 import { ProcessExecution, Task, TaskExecution, WorkspaceFolder } from "vscode";
@@ -28,13 +28,14 @@ export default class DotNetAutoAttachTask {
 		this._taskExec = taskExec;
 		this._processId = undefined;
 
-		this._projectPath = (this._taskExec.task
-			.execution as ProcessExecution).args[2];
+		const proc = this._taskExec.task.execution as ProcessExecution;
+		const cwd = proc.options ? proc.options.cwd : undefined;
+		this._projectPath = proc.args[2];
 
 		const name = DotNetAutoAttachProject.extractProjectName(this._projectPath);
 		if (name) {
 			this._project = name;
-			this._projectFolderPath = this._projectPath.substring(0, this._projectPath.length - this._project.length);
+			this._projectFolderPath = cwd ? cwd : '';
 		}
 	}
 	/**

--- a/src/models/DotNetAutoAttachTask.ts
+++ b/src/models/DotNetAutoAttachTask.ts
@@ -4,7 +4,7 @@
  * @Author: Konrad Müller
  * @Date: 2018-06-15 14:34:31
  * @Last Modified by: Luiz Stangarlin
- * @Last Modified time: 2019-12-24 12:21:49
+ * @Last Modified time: 2019-12-24 14:48:51
  */
 
 import { ProcessExecution, Task, TaskExecution, WorkspaceFolder } from "vscode";
@@ -34,7 +34,7 @@ export default class DotNetAutoAttachTask {
 		const name = DotNetAutoAttachProject.extractProjectName(this._projectPath);
 		if (name) {
 			this._project = name;
-			this._projectFolderPath = this._projectPath.substring(0, this.ProjectPath.length - this.Project.length - 2);
+			this._projectFolderPath = this._projectPath.substring(0, this._projectPath.length - this._project.length);
 		}
 	}
 	/**

--- a/src/models/DotNetAutoAttachTask.ts
+++ b/src/models/DotNetAutoAttachTask.ts
@@ -3,11 +3,12 @@
  * @Author: Dennis Jung
  * @Author: Konrad Müller
  * @Date: 2018-06-15 14:34:31
- * @Last Modified by: Dennis Jung
- * @Last Modified time: 2019-01-26 12:18:51
+ * @Last Modified by: Luiz Stangarlin
+ * @Last Modified time: 2019-12-24 12:21:49
  */
 
 import { ProcessExecution, Task, TaskExecution, WorkspaceFolder } from "vscode";
+import DotNetAutoAttachProject from "./dotNetAutoAttachProject";
 
 /**
  * The DotNetAutoAttachTask, represents a running AutoAttachTask
@@ -30,11 +31,10 @@ export default class DotNetAutoAttachTask {
 		this._projectPath = (this._taskExec.task
 			.execution as ProcessExecution).args[2];
 
-		const name_regex = /(^.+)(\\|\/)(.+.csproj)/;
-		let matches = name_regex.exec(this._projectPath);
-		if (matches && matches.length === 4) {
-			this._project = matches[3];
-			this._projectFolderPath = matches[1] + matches[2];
+		const name = DotNetAutoAttachProject.extractProjectName(this._projectPath);
+		if (name) {
+			this._project = name;
+			this._projectFolderPath = this._projectPath.substring(0, this.ProjectPath.length - this.Project.length - 2);
 		}
 	}
 	/**

--- a/src/models/ProjectQuickPickItem.ts
+++ b/src/models/ProjectQuickPickItem.ts
@@ -3,11 +3,12 @@
  * @Author: Dennis Jung
  * @Author: Konrad Müller
  * @Date: 2018-06-15 16:42:53
- * @Last Modified by: Dennis Jung
- * @Last Modified time: 2018-06-15 16:43:29
+ * @Last Modified by: Luiz Stangarlin
+ * @Last Modified time: 2019-12-24 12:22:33
  */
 
 import { QuickPickItem, Uri } from "vscode";
+import DotNetAutoAttachProject from "./dotNetAutoAttachProject";
 
 /**
  * The ProjectQuickPickItem. Represents Project that can be selected from
@@ -24,10 +25,9 @@ export default class ProjectQuickPickItem implements QuickPickItem {
 	 * @memberof ProjectQuickPickItem
 	 */
 	public constructor(uri: Uri) {
-		const name_regex = /^.+(\/|\\)(.+).csproj/;
-		let matches = name_regex.exec(uri.fsPath);
-		if (matches && matches.length === 3) {
-			this.label = matches[2];
+		const name = DotNetAutoAttachProject.extractProjectName(uri.fsPath);
+		if (name) {
+			this.label = name;
 		}
 		this.detail = uri.fsPath;
 		this.uri = uri;

--- a/src/services/task-service.ts
+++ b/src/services/task-service.ts
@@ -4,7 +4,7 @@
  * @Author: Konrad Müller
  * @Date: 2018-06-15 14:31:53
  * @Last Modified by: Luiz Stangarlin
- * @Last Modified time: 2019-12-24 12:34:56
+ * @Last Modified time: 2019-12-24 15:22:32
  */
 
 import {
@@ -129,9 +129,12 @@ export default class TaskService implements Disposable {
 		projectUri: Uri
 	): Task {
 		let projectName = "";
+		let projectPath = "";
 		const name = DotNetAutoAttachProject.extractProjectName(projectUri.fsPath);
-		if (name) {
+		const path = DotNetAutoAttachProject.extractProjectPath(projectUri.fsPath);
+		if (name && path) {
 			projectName = name;
+			projectPath = path;
 		}
 
 		let task: Task = new Task(
@@ -141,7 +144,7 @@ export default class TaskService implements Disposable {
 			"DotNet Auto Attach",
 			new ProcessExecution(
 				"dotnet",
-				["watch", "--project", projectUri.fsPath, "run"].concat(config.args),
+				["watch", "--project", projectPath, "run"].concat(config.args),
 				{ cwd: config.workspace.uri.fsPath, env: config.env }
 			),
 			"$mscompile"


### PR DESCRIPTION
Hi, thanks for this nice project, it solves this pesky attaching problem in `dotnet watch`.
But I use F#, so I made some modifications to allow F# projects. I'm using this library for testing (https://github.com/haf/expecto) with dotnet watch and now it works great with breakpoints on tests.
I should have created an issue first, but I felt like I wanted to learn how VsCode extensions worked anyway, so I hope its useful, it solved the problem for me at least.
I also fixed the "dotnet exec" parsing logic because it appears they changed it in NetCore3. We can discuss this better in an issue, or here.
